### PR TITLE
Fix reference link text/agent logs to Agent and standardize default port mappings in compose

### DIFF
--- a/README.md
+++ b/README.md
@@ -220,5 +220,5 @@ The build system uses APT package pinning to ensure version consistency:
 **Agent connection problems:**
 
 - Check network connectivity between agent and server
-- Review agent logs for connection errors
+- Review agent logs for connection errors: `docker compose logs agent`
 - Verify server address in agent configuration

--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ Minimal required configuration:
 
 Edit `conf/agent/nxagentd.conf` to configure the monitoring agent.
 
-Reference: [netxmsd.conf](https://netxms.org/documentation/adminguide/appendix.html#agent-configuration-file-nxagentd-conf).
+Reference: [nxagentd.conf](https://netxms.org/documentation/adminguide/appendix.html#agent-configuration-file-nxagentd-conf).
 
 Minimal required configuration:
 

--- a/deployment-example/compose.yaml
+++ b/deployment-example/compose.yaml
@@ -29,8 +29,8 @@ services:
       - ./conf/server/etc-netxms:/etc/netxms
       - server-var:/var/lib/netxms
     ports:
-      - 48920:4701
-      - 48921:4703
+      - 4701:4701
+      - 4703:4703
 
   agent:
     image: ghcr.io/netxms/agent:${NETXMS_VERSION:?NETXMS_VERSION environment variable is required}


### PR DESCRIPTION
This PR introduces minor fixes to the documentation and the deployment example to improve clarity and user experience for new deployments.

### Changes

1. **README.md Improvements**:

- Fixed a reference typo: Corrected the link label for the Agent configuration section which was incorrectly named `netxmsd.conf` instead of nxagentd.conf.
- **Actionable Troubleshooting**: Added a specific Docker command (`docker compose logs agent`) to the connection problems section, making it easier for users to debug agent-to-server communication issues without searching for log locations.

2. **Compose Example Standardization**:

- **Port Mapping**: Changed the external ports for the server service from `48920:4701` and `48921:4703` back to the standard NetXMS ports `4701:4701` and `4703:4703`. The current non-standard port mapping (`48920`) often leads to "Connection Refused" errors when users try to connect using the NetXMS Management Console (Rich Client) for the first time, as the desktop application defaults to port `4701`. Standardizing these ports in the deployment-example follows the principle of least surprise and aligns with the official port documentation, significantly reducing initial setup friction for new users.