### PR TITLE
[Fix] "Unable to determine database syntax" on DBInit

### DIFF
--- a/server/files/dbinit.sh
+++ b/server/files/dbinit.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-nxdbmgr -q get DBLockStatus
+output=$(nxdbmgr -q get DBLockStatus 2>&1)
 exitcode=$?
 if [ "$exitcode" -eq 5 ]; then
     driver=$(grep -im1 '^DBDriver' /etc/netxmsd.conf | cut -d= -f2 | tr -d '[:space:]' | sed 's/\.ddr$//' | tr '[:upper:]' '[:lower:]')
@@ -10,5 +10,6 @@ if [ "$exitcode" -eq 5 ]; then
         nxdbmgr init
     fi
 else
+    echo "$output ($exitcode)"
     exit $exitcode
 fi


### PR DESCRIPTION
Suppress "Unable to determine database syntax" when initializing the database, which could lead sysadmins to think that something is wrong when installing NetXMS (Docker) for the first time. On Error <> 5 it shows the `nxdbmgr` output as before.

Before:

```
root@419739ee72ee:/# ./dbinit.sh 
Unable to determine database syntax
NetXMS Database Manager Version 6.1.1 Build 6.1-452-gc20a8a4247

Initializing database...

IMPORTANT: Generated admin password
   Login:    admin
   Password: YnoablTzN24bDXYZ

Please save this password - it will not be shown again.
You will be required to change it on first login.

Database initialized successfully
```

After:

```
root@419739ee72ee:/# ./dbinit.sh 
NetXMS Database Manager Version 6.1.1 Build 6.1-452-gc20a8a4247

Initializing database...

IMPORTANT: Generated admin password
   Login:    admin
   Password: 7JZEy6m0oBG2h91i

Please save this password - it will not be shown again.
You will be required to change it on first login.

Database initialized successfully
```